### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ python connections_solver.py --mode manual --file connections/answers.json --id 
 - `--mode`: simulate or manual (default is simulate).
 - `--file`: Path to the JSON file with puzzle data.
 - `--id`: (Optional) Specific game ID to solve.
-- `--visualise`: Enable visuailsation after simulation.
+- `--visualise`: Enable visualisation after simulation.
 
 ## License
 This project is licensed under the MIT License.


### PR DESCRIPTION
## Summary
- fix a typo in the Connections solver arguments section of the README

## Testing
- `grep -n visual README.md`

------
https://chatgpt.com/codex/tasks/task_e_68405e2bb8288329b6c40ada25d5cbf4